### PR TITLE
add option to replace email server alias

### DIFF
--- a/sendmail_container/app.py
+++ b/sendmail_container/app.py
@@ -29,6 +29,7 @@ def inform_error(request, exc):
 @app.post("/sendmail/")
 def sendmail(
     sender_prefix: Optional[str] = Form("maildaemon"),
+    email_server_alias: Optional[str] = Form(envconfig.email_host),
     recipients: List[NameEmail] = Form(...),
     mail_title: Optional[str] = Form("(Empty Subject)"),
     mail_body: Optional[str] = Form(None),
@@ -37,7 +38,7 @@ def sendmail(
     try:
         with SMTP(envconfig.email_host_uri) as server:
             message = MIMEMultipart("mixed")
-            message["From"] = f"{sender_prefix}@{envconfig.email_host}"
+            message["From"] = f"{sender_prefix}@{email_server_alias}"
             message["To"] = ",".join(list(map(lambda x: x.email, recipients)))
             message["Subject"] = mail_title
             if mail_body:
@@ -51,7 +52,7 @@ def sendmail(
                     message.attach(file_attachment)
             server.connect()
             server.sendmail(
-                from_addr=f"{sender_prefix}@{envconfig.email_host}",
+                from_addr=f"{sender_prefix}@{email_server_alias}",
                 to_addrs=list(map(lambda x: x.email, recipients)),
                 msg=message.as_string(),
             )

--- a/sendmail_container/request.py
+++ b/sendmail_container/request.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import requests
-from pydantic import AnyUrl, BaseModel, validator
+from pydantic import BaseModel, validator
 from requests import HTTPError
 
 LOG = logging.getLogger(__name__)
@@ -15,6 +15,7 @@ class FormDataRequest(BaseModel):
     recipients: Union[str, List]
     mail_title: Optional[str] = None
     mail_body: Optional[str] = None
+    email_server_alias: Optional[str] = None
 
     request_uri: str
 


### PR DESCRIPTION
### Added
- Option to set email server alias (defaults to config value if not set)


### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screenshots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
