### PR TITLE
Fix(FastAPI) Optional[list] not working

### DIFF
--- a/sendmail_container/app.py
+++ b/sendmail_container/app.py
@@ -4,16 +4,19 @@ from email.mime.text import MIMEText
 from smtplib import SMTP
 from typing import List, Optional
 
+import uvicorn
 from fastapi import FastAPI, File, Form, HTTPException, Response, UploadFile
 from pydantic import NameEmail
 from pydantic_settings import BaseSettings
 
 from starlette.responses import PlainTextResponse
 
+from fastapi.responses import HTMLResponse
+
 
 class EnvConfig(BaseSettings):
     email_host: str = "localhost"
-    email_host_uri: str = "127.0.0.1"
+    email_host_uri: str = "127.0.0.1:25"
 
     class Config:
         env_file = ".env"
@@ -30,12 +33,13 @@ def inform_error(request, exc):
 
 @app.post("/sendmail/")
 def sendmail(
+    attachments: list[UploadFile],
     sender_prefix: Optional[str] = Form("maildaemon"),
     email_server_alias: Optional[str] = Form(envconfig.email_host),
     recipients: List[NameEmail] = Form(...),
     mail_title: Optional[str] = Form("(Empty Subject)"),
     mail_body: Optional[str] = Form(None),
-    attachments: Optional[List[UploadFile]] = File(None),
+
 ):
     try:
         with SMTP(envconfig.email_host_uri) as server:

--- a/sendmail_container/app.py
+++ b/sendmail_container/app.py
@@ -16,7 +16,7 @@ from fastapi.responses import HTMLResponse
 
 class EnvConfig(BaseSettings):
     email_host: str = "localhost"
-    email_host_uri: str = "127.0.0.1:25"
+    email_host_uri: str = "127.0.0.1"
 
     class Config:
         env_file = ".env"
@@ -33,12 +33,12 @@ def inform_error(request, exc):
 
 @app.post("/sendmail/")
 def sendmail(
-    attachments: list[UploadFile],
     sender_prefix: Optional[str] = Form("maildaemon"),
     email_server_alias: Optional[str] = Form(envconfig.email_host),
     recipients: List[NameEmail] = Form(...),
     mail_title: Optional[str] = Form("(Empty Subject)"),
     mail_body: Optional[str] = Form(None),
+    attachments: List[UploadFile] = File(None),
 
 ):
     try:

--- a/sendmail_container/request.py
+++ b/sendmail_container/request.py
@@ -1,10 +1,12 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Annotated
 
 import requests
-from pydantic import BaseModel, validator
-from requests import HTTPError
+from pydantic import BaseModel, BeforeValidator
+from requests import HTTPError, Response
+
+from sendmail_container.validators import split_recipients
 
 LOG = logging.getLogger(__name__)
 
@@ -12,18 +14,12 @@ LOG = logging.getLogger(__name__)
 class FormDataRequest(BaseModel):
     attachments: Optional[List[Path]] = None
     sender_prefix: Optional[str] = None
-    recipients: Union[str, List]
+    recipients: Annotated[List, BeforeValidator(split_recipients)]
     mail_title: Optional[str] = None
     mail_body: Optional[str] = None
     email_server_alias: Optional[str] = None
 
     request_uri: str
-
-    @validator("recipients")
-    def recipients_as_list(cls, value) -> List:
-        if isinstance(value, str):
-            return value.split(",")
-        return value
 
     def get_multipart_form(self) -> Tuple:
         form_data_dict = self.dict(exclude_none=True)
@@ -39,9 +35,10 @@ class FormDataRequest(BaseModel):
                 multipart_list.append((key, (None, value)))
         return tuple(multipart_list)
 
-    def submit(self) -> None:
-        response = requests.post(url=str(self.request_uri), files=self.get_multipart_form())
+    def submit(self) -> Response:
+        response: Response = requests.post(url=str(self.request_uri), files=self.get_multipart_form())
         if response.ok:
             LOG.info(f"{response.status_code}: {response.text}")
         else:
             raise HTTPError(f"{response.status_code}: {response.text}")
+        return response

--- a/sendmail_container/validators.py
+++ b/sendmail_container/validators.py
@@ -1,0 +1,7 @@
+from typing import List, Union
+
+
+def split_recipients(recipients: Union[List, str]) -> List[str]:
+    if isinstance(recipients, str):
+        return recipients.split(",")
+    return recipients

--- a/tests/run_app.py
+++ b/tests/run_app.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("sendmail_container.app:app", reload=True, host="0.0.0.0", port=8000)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,0 @@
-import uvicorn
-
-from sendmail_container.app import app
-
-if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,6 @@
+import uvicorn
+
+from sendmail_container.app import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,78 @@
+import pytest
+
+from sendmail_container.request import FormDataRequest
+
+
+def test_request_one_recipients():
+    # GIVEN a request with a single recipient
+    recipient: str = "test_email@example.com"
+
+    # WHEN creating a FormDataRequest
+    request = FormDataRequest(
+        sender_prefix="maildaemon",
+        email_server_alias="localhost",
+        recipients=recipient,
+        mail_title="Title",
+        mail_body="Body",
+        request_uri="http://localhost:8000/sendmail/", )
+
+    # THEN the recipient field should be a list with a single recipient
+    assert request.recipients == [recipient]
+    assert isinstance(request.recipients, list)
+
+
+def test_request_multiple_recipients_in_list():
+    # GIVEN a request with multiple recipients
+    recipients: list = ["test_email@example.com", "second_email@example.com"]
+
+    # WHEN creating a FormDataRequest
+    request = FormDataRequest(
+        sender_prefix="maildaemon",
+        email_server_alias="localhost",
+        recipients=recipients,
+        mail_title="Title",
+        mail_body="Body",
+        request_uri="http://localhost:8000/sendmail/", )
+
+    # THEN the recipient field should be a list with both recipients
+    assert request.recipients == recipients
+    assert isinstance(request.recipients, list)
+
+
+def test_request_multiple_recipients_in_strin():
+    # GIVEN a request with multiple recipients
+    recipients: str = "test_email@example.com,second_email@example.com"
+
+    # WHEN creating a FormDataRequest
+    request = FormDataRequest(
+        sender_prefix="maildaemon",
+        email_server_alias="localhost",
+        recipients=recipients,
+        mail_title="Title",
+        mail_body="Body",
+        request_uri="http://localhost:8000/sendmail/", )
+
+    # THEN the recipient field should be a list with both recipients
+    assert isinstance(request.recipients, list)
+    assert request.recipients == recipients.split(",")
+
+
+@pytest.mark.xfail(reason="Additional setup needed. See docstring")
+def test_request_submit():
+    """This test will fail as it requires a running sendmail app serving port 8000, as well as a running
+    SMTP server to pass."""
+
+    # GIVEN a valid request
+    request = FormDataRequest(
+        sender_prefix="maildaemon",
+        email_server_alias="localhost",
+        recipients="test_email@example.com",
+        mail_title="Title",
+        mail_body="Body",
+        request_uri="http://localhost:8000/sendmail/", )
+
+    # WHEN submitting the request
+    response = request.submit()
+
+    # THEN the response should be successful
+    assert response.ok


### PR DESCRIPTION
### Description:
There seems to be a bug where FastAPI crashes when params are typed with `Optional[list]` [see here](https://github.com/tiangolo/fastapi/pull/9928). 

This PR removes the optional, but since a default value is set, it seems to be treated as optional either way. 

I also added som pytests as well as a big xfail test that requires some set-uo

All tests where performed using python 3.11 suggesting we can change the docker base-image as well.

### Added

- tests

### Changed
- The `FormDataRequest.submit` method now returns the response
- Changed the validation for `FormDataRequest` to support pydantic v2


### Fixed

- Removed Optional type hint from attachments

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
